### PR TITLE
Allow configuring validator without specific sig alg config

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -12,11 +12,21 @@ import (
 )
 
 var (
+	emptyAudience = []string{}
+	emptyIssuer   = ""
+
+	defaultAudience = []string{"audience"}
+	defaultIssuer   = "issuer"
+
 	// The default generated token by Chrome jwt extension
 	defaultSecret         = []byte("secret")
-	defaultAudience       = []string{"audience"}
-	defaultIssuer         = "issuer"
 	defaultSecretProvider = NewKeyProvider(defaultSecret)
+
+	defaultSecretRS256         = genRSASSAJWK(jose.RS256, "")
+	defaultSecretProviderRS256 = NewKeyProvider(defaultSecretRS256.Public())
+
+	defaultSecretES384         = genECDSAJWK(jose.ES384, "")
+	defaultSecretProviderES384 = NewKeyProvider(defaultSecretES384.Public())
 )
 
 func genRSASSAJWK(sigAlg jose.SignatureAlgorithm, kid string) jose.JSONWebKey {


### PR DESCRIPTION
Add `noEnforceSigAlg` flag to JWTValidator config to allow skipping check on token sig alg when `noEnforceSigAlg` is configured as `true`. Added `NewConfigurationNoEnforceSigAlg` and kept `NewConfiguration` with `noEnforceSigAlg` defaulted to `true` for backwards compatibility.

The check for token sig alg can be safely removed in the following case where:
- in a JWKS setting, the `kid` from the JWK must correspond to one in the JWKS
- the secret provider and token secret must correspond

This would allow, in a JWKS setting, to use the same validator to validate requests that may contain JWTs of various sig alg types, corresponding to the the various JWKs with different sig alg types from the JWKS.

See updated test cases to support the pending changes.